### PR TITLE
fix: create permission class for note list view

### DIFF
--- a/notes/views.py
+++ b/notes/views.py
@@ -1,6 +1,9 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from property_direct_api.mixins import IsOwnerQuerysetFilter
-from property_direct_api.permissions import IsOwnerOrReadOnly
+from property_direct_api.permissions import (
+    AnonSafeMethodsOnly,
+    IsOwnerOrReadOnly,
+)
 from rest_framework import permissions
 from rest_framework.generics import (
     ListCreateAPIView,
@@ -21,7 +24,7 @@ class NoteListView(IsOwnerQuerysetFilter, ListCreateAPIView):
 
     model = Note
     serializer_class = NoteSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [AnonSafeMethodsOnly]
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["property"]
 

--- a/property_direct_api/permissions.py
+++ b/property_direct_api/permissions.py
@@ -51,3 +51,17 @@ class IsOwner(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return obj.owner == request.user
+
+
+class AnonSafeMethodsOnly(permissions.BasePermission):
+    """Custom Permission to allow anonymous users access to a view using safe
+    methods only, unrestricted access to authenticated users.
+    """
+
+    def has_permission(self, request, view):
+        if request.user.is_anonymous and (
+            request.method not in permissions.SAFE_METHODS
+        ):
+            return False
+        else:
+            return True


### PR DESCRIPTION
A permissions class has been created which allows access to authenticated users but only allows SAFE (read-only) request methods to be used by Anonymous users.

Previously, anonymous users would receive a 403 error when attempting to retrieve notes. This caused an unforeseen problem in the accompanying frontend application  when trying to group API calls as the request would fail when the 403 error was encountered (promise failure). The simplest solution was a permissions change in the API to deny creation of a note, but allow the retrieval of a blank array as originally intended.