### PR TITLE
fix: add profile owner id to serializer fields

### DIFF
--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -16,6 +16,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     """
 
     owner = serializers.ReadOnlyField(source="owner.username")
+    owner_id = serializers.ReadOnlyField(source="owner.id")
     is_owner = serializers.SerializerMethodField()
     following_id = serializers.SerializerMethodField()
     property_count = serializers.ReadOnlyField()
@@ -48,7 +49,6 @@ class ProfileSerializer(serializers.ModelSerializer):
         # URL:    https://emailregex.com/ - http://disq.us/p/10frbr8
         pattern = r"\S+@\S+\.\S+"
 
-        # TODO: MailGun Email Validation
         if re.match(pattern, value):
             return value
         raise serializers.ValidationError(
@@ -74,6 +74,7 @@ class ProfileSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "owner",
+            "owner_id",
             "is_owner",
             "name",
             "description",


### PR DESCRIPTION
This fix implements changes to make the frontend application more robust.

**Problem**

When making a request to follow a sellers profile, the sellers "user id" is required. In the frontend application I had planned to use the sellers "profile id" when making the post request to follow a user as they should share the same id number in an ideal scenario.

Initial testing had caused the id numbers of these tables to fall out of sync so the "profile id" could not be relied upon to match the "user id".

**Solution**

This change returns the profile owners id as part of the profile information which can reliably be used to create a follow request. If this were to happen due to user moderation/manipulation by the DB admin in a production environment, this will no longer cause a difficult to diagnose 400 error.